### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Descope MCP Server
 [![smithery badge](https://smithery.ai/badge/@descope-sample-apps/descope-mcp-server)](https://smithery.ai/server/@descope-sample-apps/descope-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/xr7eiu0phx"><img width="380" height="200" src="https://glama.ai/mcp/servers/xr7eiu0phx/badge" alt="descope-mcp-server MCP server" /></a>
+
 ## Introduction
 
 The Descope Model Context Protocol (MCP) server provides an interface to interact with Descope's Management APIs, enabling the search and retrieval of project-related information.


### PR DESCRIPTION
This PR adds a badge for the [descope-mcp-server](https://glama.ai/mcp/servers/xr7eiu0phx) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xr7eiu0phx"><img width="380" height="200" src="https://glama.ai/mcp/servers/xr7eiu0phx/badge" alt="descope-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.