### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 The Descope Model Context Protocol (MCP) server provides an interface to interact with Descope's Management APIs, enabling the search and retrieval of project-related information.
 
+<a href="https://glama.ai/mcp/servers/@descope-sample-apps/descope-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@descope-sample-apps/descope-mcp-server/badge" alt="Descope Server MCP server" />
+</a>
+
 ## Available Tools
 
 - `search-audits`: Retrieves up to 10 audit log entries from your Descope project.


### PR DESCRIPTION
This PR adds a badge for the [Descope MCP Server](https://glama.ai/mcp/servers/@descope-sample-apps/descope-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@descope-sample-apps/descope-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@descope-sample-apps/descope-mcp-server/badge" alt="Descope Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.